### PR TITLE
Fix CI build: launch Puppeteer with --no-sandbox

### DIFF
--- a/scripts/generate-cv-pdf.mjs
+++ b/scripts/generate-cv-pdf.mjs
@@ -37,7 +37,9 @@ function serveDocs() {
 const server = await serveDocs();
 
 try {
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  });
   const page = await browser.newPage();
   await page.goto(`http://localhost:${PORT}/cv/`, { waitUntil: "networkidle0" });
   await page.emulateMediaType("print");


### PR DESCRIPTION
## Summary
The Actions build (run 31969353249) failed after a fully successful Astro build — the CV PDF generation step crashed launching Chrome: `No usable sandbox!`. GitHub's Ubuntu runners don't support Chrome's default sandboxing without extra host setup, which is the standard reason Puppeteer needs `--no-sandbox` in CI. Safe here since we're only rendering our own already-built site, not untrusted content.

## Test plan
- [x] `npm run build` succeeds locally and produces `docs/pete-benbow-cv.pdf`
- [ ] Actions run succeeds on this PR/after merge