### PR TITLE
Fix CI deploy: grant id-token/pages permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,11 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Build succeeded but the deploy job failed instantly: "Ensure GITHUB_TOKEN has permission \"id-token: write\"." `actions/deploy-pages` authenticates via OIDC, which requires `id-token: write` (and `pages: write`) to be explicitly granted — the workflow had no `permissions:` block, so it fell back to the repo's default token permissions, which didn't include either.

## Test plan
- [ ] Actions run succeeds end-to-end (build + deploy) after merge
- [ ] petebenbow.com serves the new site