### PR TITLE
Stylize the CV page with cards and iconography

### DIFF
--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -203,7 +203,7 @@ export const honors = [
 ];
 
 export const skills: SkillGroup[] = [
-  { category: "Languages", icon: "lucide:code-2", items: ["SQL", "R", "Python"] },
+  { category: "Languages", icon: "lucide:code", items: ["SQL", "R", "Python"] },
   { category: "Databases", icon: "lucide:database", items: ["PostgreSQL", "Microsoft SQL Server", "MySQL", "Oracle RDBMS", "DuckDB", "MongoDB"] },
   { category: "BI & Data Viz", icon: "lucide:bar-chart-3", items: ["ggplot2", "Power BI", "R Shiny", "Tableau", "Superset"] },
   { category: "Data Engineering", icon: "lucide:workflow", items: ["Databricks", "Microsoft Fabric", "Duckle", "Spark", "Polars"] },

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,6 +1,8 @@
 ---
+import { Icon } from "astro-icon/components";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Glow from "../components/Glow.astro";
+import { socialLinks } from "../data/social";
 import {
 	education,
 	experience,
@@ -10,21 +12,50 @@ import {
 	professionalService,
 	honors,
 } from "../data/cv";
+
+interface SectionProps {
+	icon: string;
+	title: string;
+}
+
+const sectionHeadingClass =
+	"flex items-center gap-2.5 print:gap-0";
+const iconBadgeClass =
+	"flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent-500/10 text-accent-400 print:hidden";
+const headingTextClass =
+	"font-display text-xl font-semibold text-ink-50 print:text-black";
+const cardClass =
+	"rounded-xl border border-ink-800 bg-ink-900 p-6 print:rounded-none print:border-0 print:bg-transparent print:p-0";
 ---
 
 <BaseLayout title="Pete Benbow — Curriculum Vitae" description="Curriculum Vitae for Pete Benbow, Assistant Professor of the Practice in Data Science at Davidson College.">
 	<article id="cv" class="relative mx-auto max-w-3xl px-6 py-20 print:max-w-none print:px-0 print:py-0">
 		<Glow color="var(--color-accent-500)" class="-top-20 -right-32" />
+
 		<div class="flex flex-wrap items-start justify-between gap-4 print:hidden">
 			<div>
 				<h1 class="font-display text-4xl font-bold text-ink-50">Curriculum Vitae</h1>
 				<p class="mt-1 text-ink-400">Pete Benbow</p>
+				<div class="mt-3 flex items-center gap-4">
+					{socialLinks.map((link) => (
+						<a
+							href={link.href}
+							target="_blank"
+							rel="noreferrer"
+							aria-label={link.label}
+							class="text-ink-400 transition-colors hover:text-accent-400"
+						>
+							<Icon name={link.icon} class="h-5 w-5" />
+						</a>
+					))}
+				</div>
 			</div>
 			<a
 				href="/pete-benbow-cv.pdf"
-				class="rounded-full bg-accent-500 px-6 py-2.5 text-sm font-semibold text-ink-50 transition-all duration-200 hover:-translate-y-0.5 hover:bg-accent-600 hover:shadow-lg hover:shadow-accent-500/30"
+				class="flex items-center gap-2 rounded-full bg-accent-500 px-6 py-2.5 text-sm font-semibold text-ink-50 transition-all duration-200 hover:-translate-y-0.5 hover:bg-accent-600 hover:shadow-lg hover:shadow-accent-500/30"
 				download
 			>
+				<Icon name="lucide:download" class="h-4 w-4" />
 				Download PDF
 			</a>
 		</div>
@@ -32,107 +63,141 @@ import {
 		<h1 class="hidden font-display text-3xl font-bold text-black print:mb-1 print:block">Pete Benbow — Curriculum Vitae</h1>
 
 		<section class="mt-12 print:mt-4">
-			<h2 class="font-display text-xl font-semibold text-ink-50 print:text-black">Education</h2>
-			<ul class="mt-3 space-y-1 text-ink-200 print:text-black">
-				{education.map((entry) => (
-					<li>{entry.degree} ({entry.year}), {entry.institution}</li>
-				))}
-			</ul>
+			<div class={sectionHeadingClass}>
+				<span class={iconBadgeClass}><Icon name="lucide:graduation-cap" class="h-4 w-4" /></span>
+				<h2 class={headingTextClass}>Education</h2>
+			</div>
+			<div class={`mt-3 ${cardClass}`}>
+				<ul class="space-y-1 text-ink-200 print:text-black">
+					{education.map((entry) => (
+						<li>{entry.degree} ({entry.year}), {entry.institution}</li>
+					))}
+				</ul>
+			</div>
 		</section>
 
-		<section class="mt-10 print:mt-4">
-			<h2 class="font-display text-xl font-semibold text-ink-50 print:text-black">Experience</h2>
-			{experience.map((org) => (
-				<div class="mt-4">
-					<h3 class="font-display text-base font-semibold text-ink-100 print:text-black">{org.name}</h3>
-					<div class="mt-2 space-y-4">
-						{org.roles.map((role) => (
-							<div>
-								<p class="font-medium text-ink-200 print:text-black">
-									{role.title}
-									{role.dates && <span class="text-ink-400 print:text-neutral-600"> ({role.dates})</span>}
-								</p>
-								{role.bullets && role.bullets.length > 0 && (
-									<ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
-										{role.bullets.map((bullet) => <li>{bullet}</li>)}
-									</ul>
-								)}
-							</div>
-						))}
+		<section class="mt-8 print:mt-4">
+			<div class={sectionHeadingClass}>
+				<span class={iconBadgeClass}><Icon name="lucide:briefcase" class="h-4 w-4" /></span>
+				<h2 class={headingTextClass}>Experience</h2>
+			</div>
+			<div class="mt-3 space-y-5">
+				{experience.map((org) => (
+					<div class={cardClass}>
+						<h3 class="font-display text-base font-semibold text-ink-100 print:text-black">{org.name}</h3>
+						<div class="mt-4 space-y-5 border-l border-ink-700 pl-5 print:mt-2 print:space-y-3 print:border-0 print:pl-0">
+							{org.roles.map((role) => (
+								<div class="relative">
+									<span class="absolute top-1.5 -left-[1.4rem] h-2 w-2 rounded-full bg-accent-500 print:hidden"></span>
+									<p class="font-medium text-ink-200 print:text-black">
+										{role.title}
+										{role.dates && <span class="text-ink-400 print:text-neutral-600"> ({role.dates})</span>}
+									</p>
+									{role.bullets && role.bullets.length > 0 && (
+										<ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+											{role.bullets.map((bullet) => <li>{bullet}</li>)}
+										</ul>
+									)}
+								</div>
+							))}
+						</div>
 					</div>
-				</div>
-			))}
+				))}
+			</div>
 		</section>
 
-		<section class="mt-10 print:mt-4">
-			<h2 class="font-display text-xl font-semibold text-ink-50 print:text-black">Teaching</h2>
-			<h3 class="mt-3 font-display text-base font-semibold text-ink-100 print:text-black">Classroom Instruction</h3>
-			<ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
-				{teaching.classroom.map((item) => <li>{item}</li>)}
-			</ul>
-			<h3 class="mt-4 font-display text-base font-semibold text-ink-100 print:text-black">Online Instruction (edX)</h3>
-			<ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
-				{teaching.online.map((item) => <li>{item}</li>)}
-			</ul>
+		<section class="mt-8 print:mt-4">
+			<div class={sectionHeadingClass}>
+				<span class={iconBadgeClass}><Icon name="lucide:book-open" class="h-4 w-4" /></span>
+				<h2 class={headingTextClass}>Teaching</h2>
+			</div>
+			<div class={`mt-3 ${cardClass}`}>
+				<h3 class="font-display text-base font-semibold text-ink-100 print:text-black">Classroom Instruction</h3>
+				<ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+					{teaching.classroom.map((item) => <li>{item}</li>)}
+				</ul>
+				<h3 class="mt-4 font-display text-base font-semibold text-ink-100 print:text-black">Online Instruction (edX)</h3>
+				<ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+					{teaching.online.map((item) => <li>{item}</li>)}
+				</ul>
+			</div>
 		</section>
 
-		<section class="mt-10 print:mt-4">
-			<h2 class="font-display text-xl font-semibold text-ink-50 print:text-black">Software Development</h2>
-			{software.map((group) => (
-				<div class="mt-4">
-					<h3 class="font-display text-base font-semibold text-ink-100 print:text-black">{group.category}</h3>
-					<ul class="mt-2 space-y-2 text-sm text-ink-400 print:text-neutral-700">
-						{group.projects.map((project) => (
-							<li>
-								<span class="font-medium text-ink-200 print:text-black">{project.name}</span>: {project.description}
-								{project.role && <span> — {project.role}</span>}
-								{project.links && project.links.length > 0 && (
-									<span>
-										{" "}(
-										{project.links.map((link, i) => (
-											<>
-												{i > 0 && " | "}
-												<a href={link.href} target="_blank" rel="noreferrer" class="text-accent-400 print:text-black print:underline">{link.label}</a>
-											</>
-										))}
-										)
-									</span>
-								)}
-							</li>
-						))}
-					</ul>
-				</div>
-			))}
+		<section class="mt-8 print:mt-4">
+			<div class={sectionHeadingClass}>
+				<span class={iconBadgeClass}><Icon name="lucide:code" class="h-4 w-4" /></span>
+				<h2 class={headingTextClass}>Software Development</h2>
+			</div>
+			<div class="mt-3 grid gap-4 sm:grid-cols-2 print:block print:space-y-3">
+				{software.map((group) => (
+					<div class={cardClass}>
+						<h3 class="font-display text-base font-semibold text-ink-100 print:text-black">{group.category}</h3>
+						<ul class="mt-2 space-y-2 text-sm text-ink-400 print:text-neutral-700">
+							{group.projects.map((project) => (
+								<li>
+									<span class="font-medium text-ink-200 print:text-black">{project.name}</span>: {project.description}
+									{project.role && <span> — {project.role}</span>}
+									{project.links && project.links.length > 0 && (
+										<span>
+											{" "}(
+											{project.links.map((link, i) => (
+												<>
+													{i > 0 && " | "}
+													<a href={link.href} target="_blank" rel="noreferrer" class="text-accent-400 print:text-black print:underline">{link.label}</a>
+												</>
+											))}
+											)
+										</span>
+									)}
+								</li>
+							))}
+						</ul>
+					</div>
+				))}
+			</div>
 		</section>
 
-		<section class="mt-10 print:mt-4">
-			<h2 class="font-display text-xl font-semibold text-ink-50 print:text-black">Conferences &amp; Presentations</h2>
-			<ul class="mt-3 space-y-3 text-sm text-ink-400 print:text-neutral-700">
+		<section class="mt-8 print:mt-4">
+			<div class={sectionHeadingClass}>
+				<span class={iconBadgeClass}><Icon name="lucide:mic" class="h-4 w-4" /></span>
+				<h2 class={headingTextClass}>Conferences &amp; Presentations</h2>
+			</div>
+			<div class="mt-3 space-y-3">
 				{conferences.map((conf) => (
-					<li>
+					<div class={cardClass}>
 						<p class="font-medium text-ink-200 print:text-black">
 							“{conf.title}”{conf.note && <span>, {conf.note}</span>}
 						</p>
-						<ul class="mt-1 list-disc space-y-0.5 pl-5">
+						<ul class="mt-1 list-disc space-y-0.5 pl-5 text-sm text-ink-400 print:text-neutral-700">
 							{conf.presentations.map((p) => <li>{p.venue} ({p.date})</li>)}
 						</ul>
-					</li>
+					</div>
 				))}
-			</ul>
+			</div>
 		</section>
 
-		<section class="mt-10 print:mt-4">
-			<h2 class="font-display text-xl font-semibold text-ink-50 print:text-black">Professional Service</h2>
-			<ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
-				{professionalService.map((item) => <li>{item}</li>)}
-			</ul>
+		<section class="mt-8 print:mt-4">
+			<div class={sectionHeadingClass}>
+				<span class={iconBadgeClass}><Icon name="lucide:handshake" class="h-4 w-4" /></span>
+				<h2 class={headingTextClass}>Professional Service</h2>
+			</div>
+			<div class={`mt-3 ${cardClass}`}>
+				<ul class="list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+					{professionalService.map((item) => <li>{item}</li>)}
+				</ul>
+			</div>
 		</section>
 
-		<section class="mt-10 print:mt-4">
-			<h2 class="font-display text-xl font-semibold text-ink-50 print:text-black">Honors and Awards</h2>
-			<ul class="mt-3 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
-				{honors.map((item) => <li>{item}</li>)}
-			</ul>
+		<section class="mt-8 print:mt-4">
+			<div class={sectionHeadingClass}>
+				<span class={iconBadgeClass}><Icon name="lucide:award" class="h-4 w-4" /></span>
+				<h2 class={headingTextClass}>Honors and Awards</h2>
+			</div>
+			<div class={`mt-3 ${cardClass}`}>
+				<ul class="list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+					{honors.map((item) => <li>{item}</li>)}
+				</ul>
+			</div>
 		</section>
 	</article>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -144,7 +144,7 @@ const talks = (await getCollection("talks")).sort(
 
 	<section id="code" class="relative mx-auto max-w-5xl px-6 py-24">
 		<Glow color="var(--color-accent-500)" class="top-0 right-1/4" />
-		<SectionHeading icon="lucide:code-2" title="Code" description="R packages and tools I've built or contributed to." />
+		<SectionHeading icon="lucide:code" title="Code" description="R packages and tools I've built or contributed to." />
 		<div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 			{codeItems.map((item) => (
 				<Card


### PR DESCRIPTION
## Summary
- Every CV section (Education, Experience, Teaching, Software, Conferences, Service, Honors) now has an icon badge next to its heading and its content sits inside card containers, matching the visual language used on the rest of the site
- Experience gets a small left-rail timeline with dot markers per role
- Added a compact contact icon row under the name (GitHub/LinkedIn/College bio/Spotify) and a download icon on the PDF button
- All the new visual chrome (icon badges, card borders/backgrounds, timeline dots) is stripped via `print:` overrides, so the generated PDF stays a clean, traditional single-column resume — unaffected by the on-screen styling
- Bonus fix: `lucide:code-2` isn't a real icon in the installed set (correct name is `code`), so the Skills "Languages" badge and the home page's Code section heading were silently rendering blank. Fixed both while auditing icon names for this change.

## Test plan
- [x] `npm run build` succeeds, generates all pages + `docs/pete-benbow-cv.pdf`
- [x] Verified all new icon names exist in the installed lucide/simple-icons sets before using them
- [x] Confirmed the generated PDF is still a valid, reasonably-sized file
- [ ] Visual review in a browser (no screenshot tooling in the environment this was built in — please eyeball `/cv` and the downloaded PDF before merging)