### PR TITLE
Add CV table of contents, bigger body text, and more glow

### DIFF
--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -13,10 +13,15 @@ import {
 	honors,
 } from "../data/cv";
 
-interface SectionProps {
-	icon: string;
-	title: string;
-}
+const tocSections = [
+	{ id: "education", icon: "lucide:graduation-cap", title: "Education" },
+	{ id: "experience", icon: "lucide:briefcase", title: "Experience" },
+	{ id: "teaching", icon: "lucide:book-open", title: "Teaching" },
+	{ id: "software", icon: "lucide:code", title: "Software Development" },
+	{ id: "conferences", icon: "lucide:mic", title: "Conferences & Presentations" },
+	{ id: "service", icon: "lucide:handshake", title: "Professional Service" },
+	{ id: "honors", icon: "lucide:award", title: "Honors and Awards" },
+];
 
 const sectionHeadingClass =
 	"flex items-center gap-2.5 print:gap-0";
@@ -26,11 +31,15 @@ const headingTextClass =
 	"font-display text-xl font-semibold text-ink-50 print:text-black";
 const cardClass =
 	"rounded-xl border border-ink-800 bg-ink-900 p-6 print:rounded-none print:border-0 print:bg-transparent print:p-0";
+const bodyListClass =
+	"text-base text-ink-400 print:text-sm print:text-neutral-700";
 ---
 
 <BaseLayout title="Pete Benbow — Curriculum Vitae" description="Curriculum Vitae for Pete Benbow, Assistant Professor of the Practice in Data Science at Davidson College.">
 	<article id="cv" class="relative mx-auto max-w-3xl px-6 py-20 print:max-w-none print:px-0 print:py-0">
 		<Glow color="var(--color-accent-500)" class="-top-20 -right-32" />
+		<Glow color="var(--color-violet-500)" class="top-[45%] -left-40" />
+		<Glow color="var(--color-coral-500)" class="bottom-0 -right-32" />
 
 		<div class="flex flex-wrap items-start justify-between gap-4 print:hidden">
 			<div>
@@ -62,7 +71,24 @@ const cardClass =
 
 		<h1 class="hidden font-display text-3xl font-bold text-black print:mb-1 print:block">Pete Benbow — Curriculum Vitae</h1>
 
-		<section class="mt-12 print:mt-4">
+		<nav class={`mt-8 print:hidden ${cardClass}`} aria-label="Table of contents">
+			<p class="font-display text-xs font-semibold uppercase tracking-wider text-ink-400">On this page</p>
+			<ul class="mt-3 grid gap-2 sm:grid-cols-2">
+				{tocSections.map((s) => (
+					<li>
+						<a
+							href={`#${s.id}`}
+							class="flex items-center gap-2 text-sm font-medium text-ink-200 transition-colors hover:text-accent-400"
+						>
+							<Icon name={s.icon} class="h-4 w-4 text-accent-400" />
+							{s.title}
+						</a>
+					</li>
+				))}
+			</ul>
+		</nav>
+
+		<section id="education" class="mt-8 print:mt-4">
 			<div class={sectionHeadingClass}>
 				<span class={iconBadgeClass}><Icon name="lucide:graduation-cap" class="h-4 w-4" /></span>
 				<h2 class={headingTextClass}>Education</h2>
@@ -76,7 +102,7 @@ const cardClass =
 			</div>
 		</section>
 
-		<section class="mt-8 print:mt-4">
+		<section id="experience" class="mt-8 print:mt-4">
 			<div class={sectionHeadingClass}>
 				<span class={iconBadgeClass}><Icon name="lucide:briefcase" class="h-4 w-4" /></span>
 				<h2 class={headingTextClass}>Experience</h2>
@@ -94,7 +120,7 @@ const cardClass =
 										{role.dates && <span class="text-ink-400 print:text-neutral-600"> ({role.dates})</span>}
 									</p>
 									{role.bullets && role.bullets.length > 0 && (
-										<ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+										<ul class={`mt-1 list-disc space-y-1 pl-5 ${bodyListClass}`}>
 											{role.bullets.map((bullet) => <li>{bullet}</li>)}
 										</ul>
 									)}
@@ -106,24 +132,24 @@ const cardClass =
 			</div>
 		</section>
 
-		<section class="mt-8 print:mt-4">
+		<section id="teaching" class="mt-8 print:mt-4">
 			<div class={sectionHeadingClass}>
 				<span class={iconBadgeClass}><Icon name="lucide:book-open" class="h-4 w-4" /></span>
 				<h2 class={headingTextClass}>Teaching</h2>
 			</div>
 			<div class={`mt-3 ${cardClass}`}>
 				<h3 class="font-display text-base font-semibold text-ink-100 print:text-black">Classroom Instruction</h3>
-				<ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+				<ul class={`mt-1 list-disc space-y-1 pl-5 ${bodyListClass}`}>
 					{teaching.classroom.map((item) => <li>{item}</li>)}
 				</ul>
 				<h3 class="mt-4 font-display text-base font-semibold text-ink-100 print:text-black">Online Instruction (edX)</h3>
-				<ul class="mt-1 list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+				<ul class={`mt-1 list-disc space-y-1 pl-5 ${bodyListClass}`}>
 					{teaching.online.map((item) => <li>{item}</li>)}
 				</ul>
 			</div>
 		</section>
 
-		<section class="mt-8 print:mt-4">
+		<section id="software" class="mt-8 print:mt-4">
 			<div class={sectionHeadingClass}>
 				<span class={iconBadgeClass}><Icon name="lucide:code" class="h-4 w-4" /></span>
 				<h2 class={headingTextClass}>Software Development</h2>
@@ -132,7 +158,7 @@ const cardClass =
 				{software.map((group) => (
 					<div class={cardClass}>
 						<h3 class="font-display text-base font-semibold text-ink-100 print:text-black">{group.category}</h3>
-						<ul class="mt-2 space-y-2 text-sm text-ink-400 print:text-neutral-700">
+						<ul class={`mt-2 space-y-2 ${bodyListClass}`}>
 							{group.projects.map((project) => (
 								<li>
 									<span class="font-medium text-ink-200 print:text-black">{project.name}</span>: {project.description}
@@ -157,7 +183,7 @@ const cardClass =
 			</div>
 		</section>
 
-		<section class="mt-8 print:mt-4">
+		<section id="conferences" class="mt-8 print:mt-4">
 			<div class={sectionHeadingClass}>
 				<span class={iconBadgeClass}><Icon name="lucide:mic" class="h-4 w-4" /></span>
 				<h2 class={headingTextClass}>Conferences &amp; Presentations</h2>
@@ -168,7 +194,7 @@ const cardClass =
 						<p class="font-medium text-ink-200 print:text-black">
 							“{conf.title}”{conf.note && <span>, {conf.note}</span>}
 						</p>
-						<ul class="mt-1 list-disc space-y-0.5 pl-5 text-sm text-ink-400 print:text-neutral-700">
+						<ul class={`mt-1 list-disc space-y-0.5 pl-5 ${bodyListClass}`}>
 							{conf.presentations.map((p) => <li>{p.venue} ({p.date})</li>)}
 						</ul>
 					</div>
@@ -176,25 +202,25 @@ const cardClass =
 			</div>
 		</section>
 
-		<section class="mt-8 print:mt-4">
+		<section id="service" class="mt-8 print:mt-4">
 			<div class={sectionHeadingClass}>
 				<span class={iconBadgeClass}><Icon name="lucide:handshake" class="h-4 w-4" /></span>
 				<h2 class={headingTextClass}>Professional Service</h2>
 			</div>
 			<div class={`mt-3 ${cardClass}`}>
-				<ul class="list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+				<ul class={`list-disc space-y-1 pl-5 ${bodyListClass}`}>
 					{professionalService.map((item) => <li>{item}</li>)}
 				</ul>
 			</div>
 		</section>
 
-		<section class="mt-8 print:mt-4">
+		<section id="honors" class="mt-8 print:mt-4">
 			<div class={sectionHeadingClass}>
 				<span class={iconBadgeClass}><Icon name="lucide:award" class="h-4 w-4" /></span>
 				<h2 class={headingTextClass}>Honors and Awards</h2>
 			</div>
 			<div class={`mt-3 ${cardClass}`}>
-				<ul class="list-disc space-y-1 pl-5 text-sm text-ink-400 print:text-neutral-700">
+				<ul class={`list-disc space-y-1 pl-5 ${bodyListClass}`}>
 					{honors.map((item) => <li>{item}</li>)}
 				</ul>
 			</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,6 +27,11 @@
 }
 
 @layer base {
+  html {
+    scroll-padding-top: 6rem;
+    scroll-behavior: smooth;
+  }
+
   body {
     background-color: var(--color-ink-950);
     color: var(--color-ink-50);


### PR DESCRIPTION
- Adds an "On this page" card linking to each of the 7 CV sections (ids added to each <section>), hidden in print
- Bumps body/bullet text from text-sm to text-base on screen (kept at the original text-sm in print so the PDF doesn't reflow/grow)
- Adds two more glows (violet mid-page, coral toward the bottom) so the ambient background carries further down the page instead of fading out after the header
- Global scroll-padding-top + scroll-behavior: smooth so anchor links (this new TOC, and the existing home page nav) land below the sticky header instead of getting hidden behind it